### PR TITLE
Fix occasional invalid elements in result

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ var intersect = function(lists, opts) {
 				var valB = listB[offsetB];
 
 				if (valA > valB) {
+					matches = 0;
 					offsetB = gallop(listB, valA, offsetB, 0);
 					continue;
 				}

--- a/test.js
+++ b/test.js
@@ -27,6 +27,13 @@ assert.deepEqual(intersect([
 ]), []);
 
 assert.deepEqual(intersect([
+	[1,3],
+	[1,2,3],
+	[1,2,3],
+	[1,2,4]
+]), [1]);
+
+assert.deepEqual(intersect([
 	[1,3,4,5],
 	[3,4,5],
 	[2,3,4,5,6,7]


### PR DESCRIPTION
Looks like a typo, which could lead to elements being included in the intersection result that weren't actually present in all input arrays.

A test case that fails without the fix has been added.

Thanks for writing this truly high-performance module! I first wrote my own implementation before I found yours, and while comparing performance (yours being a lot faster due to the "galloping") and results, I came across this bug.